### PR TITLE
Fix: CORS 에러 해결 (모든 헤더를 허용)

### DIFF
--- a/server/src/main/java/com/notfound/stackoverflowclone/config/SecurityConfiguration.java
+++ b/server/src/main/java/com/notfound/stackoverflowclone/config/SecurityConfiguration.java
@@ -40,8 +40,6 @@ public class SecurityConfiguration {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-                .headers().frameOptions().sameOrigin()
-                .and()
                 .csrf().disable()
                 .cors(withDefaults())
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)


### PR DESCRIPTION
요청에 특정헤더가 있으면 CORS설정이 걸렸던거 같습니다. 어떤 헤더였는지는 모르겠습니다.