### PR TITLE
Fix: 질문조회와 질문수정 요청이 동시에 들어올때 발생하는 버그 수정

### DIFF
--- a/server/src/main/java/com/notfound/stackoverflowclone/question/repository/QuestionRepository.java
+++ b/server/src/main/java/com/notfound/stackoverflowclone/question/repository/QuestionRepository.java
@@ -4,7 +4,14 @@ import com.notfound.stackoverflowclone.question.entity.Question;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface QuestionRepository extends JpaRepository<Question, Long> {
     Page<Question> findAllByTitleContainsOrContentContains(String title, String content, Pageable pageable);
+
+    @Modifying(clearAutomatically = true)
+    @Query("update Question q set q.views = q.views + 1 where q = :q")
+    void updateView(@Param("q") Question question);
 }

--- a/server/src/main/java/com/notfound/stackoverflowclone/question/service/QuestionService.java
+++ b/server/src/main/java/com/notfound/stackoverflowclone/question/service/QuestionService.java
@@ -96,8 +96,8 @@ public class QuestionService {
 
     public Question findViewedQuestion(Long questionId) {
         Question findQuestion = findVerifiedQuestion(questionId);
-        findQuestion.setViews(findQuestion.getViews() + 1);
-        return findQuestion;
+        questionRepository.updateView(findQuestion);
+        return findVerifiedQuestion(questionId);
     }
 
 


### PR DESCRIPTION
질문 조회와 질문 수정 요청이 동시에 일어날때 문제가 있습니다.

현재 -> 원래제목, 원래내용, 조회수 1 인 상태에서
time 1 -> 수정된 제목, 수정된 내용, 조회수 1 로 update 요청
time 2 -> (질문조회시) 원래제목, 원래내용, 조회수 2 로 update 요청
time 3 -> 수정된 제목, 수정된 내용, 조회수 1로 update 완료 -> 응답
time 4 -> 원래제목, 원래내용, 조회수 2 로 update 요청 완료 -> 응답
최종적으로 원래제목, 원래내용, 조회수 2 만 남게됩니다.

이부분을 수정하여 질문조회시에는 조회수 컬럼만 단독으로 올리는 쿼리를 실행합니다.